### PR TITLE
Non text bytes in the header

### DIFF
--- a/src/init_parsing.jl
+++ b/src/init_parsing.jl
@@ -101,7 +101,8 @@ function process_header_and_schema_and_finish_row_skip!(
                     try
                         push!(parsing_ctx.header, Symbol(identifier_s))
                     catch
-                        throw(HeaderParsingError("Error parsing header for column $i ('$(identifier_s)') at " *
+                        # defensively truncate identifier_s to 2k characters in case something is very cursed
+                        throw(HeaderParsingError("Error parsing header for column $i ('$(first(identifier_s, 2000))') at " *
                             "$(lines_skipped_total+1):$pos (row:pos): presence of invalid non text bytes in the CSV snippet"))
                     end
                 end
@@ -176,7 +177,8 @@ function process_header_and_schema_and_finish_row_skip!(
                 try
                     push!(parsing_ctx.header, Symbol(identifier_s))
                 catch
-                    throw(HeaderParsingError("Error parsing header for column $i ('$(identifier_s)') at " *
+                    # defensively truncate identifier_s to 2k characters in case something is very cursed
+                    throw(HeaderParsingError("Error parsing header for column $i ('$(first(identifier_s, 2000))') at " *
                         "$(lines_skipped_total+1):$pos (row:pos): presence of invalid non text bytes in the CSV snippet"))
                 end
             end

--- a/src/init_parsing.jl
+++ b/src/init_parsing.jl
@@ -97,7 +97,13 @@ function process_header_and_schema_and_finish_row_skip!(
                 elseif !Parsers.ok(code)
                     throw(HeaderParsingError("Error parsing header for column $i at $(lines_skipped_total+1):$(pos) (row:pos)."))
                 else
-                    push!(parsing_ctx.header, Symbol(strip(Parsers.getstring(row_bytes, val, options.e))))
+                    identifier_s = strip(Parsers.getstring(row_bytes, val, options.e))
+                    try
+                        push!(parsing_ctx.header, Symbol(identifier_s))
+                    catch
+                        throw(HeaderParsingError("Error parsing header for column $i ('$(identifier_s)') at " *
+                            "$(lines_skipped_total+1):$pos (row:pos): presence of invalid non text bytes in the CSV snippet"))
+                    end
                 end
                 pos += tlen
             end
@@ -166,7 +172,13 @@ function process_header_and_schema_and_finish_row_skip!(
             elseif !Parsers.ok(code)
                 throw(HeaderParsingError("Error parsing header for column $i at $(lines_skipped_total+1):$pos (row:pos)."))
             else
-                push!(parsing_ctx.header, Symbol(strip(Parsers.getstring(row_bytes, val, options.e))))
+                identifier_s = strip(Parsers.getstring(row_bytes, val, options.e))
+                try
+                    push!(parsing_ctx.header, Symbol(identifier_s))
+                catch
+                    throw(HeaderParsingError("Error parsing header for column $i ('$(identifier_s)') at " *
+                        "$(lines_skipped_total+1):$pos (row:pos): presence of invalid non text bytes in the CSV snippet"))
+                end
             end
             pos += tlen
             i += 1

--- a/test/exception_handling.jl
+++ b/test/exception_handling.jl
@@ -228,6 +228,14 @@ end
         header=true,
     )
 
+    @test_throws ChunkedCSV.HeaderParsingError("Error parsing header for column 1 ('a\0') at 1:1 (row:pos): presence of invalid non text bytes in the CSV snippet") parse_file(IOBuffer("""
+        a\0,b
+        1,2
+        """),
+        [Int,Int],
+        header=true,
+    )
+
     @test_throws ArgumentError("Provided header and schema names don't match. In schema, not in header: [:q]. In header, not in schema: [:a, :b, :c]") parse_file(IOBuffer("""
         a,b,c
         1,2,3


### PR DESCRIPTION
It provides a better description of the error when one of the column cannot be converted to a symbol, due to the presence of the null byte (\0) or whatever invalid other character.

Ref NCDNTS-2221
