### PR TITLE
Remove `UnknownTypeError` and other misc cleanup

### DIFF
--- a/src/parse_file.jl
+++ b/src/parse_file.jl
@@ -261,7 +261,7 @@ function parse_file(
         result_buffers = _make_result_buffers(nbuffers, schema, cld(nrows, ntasks))
         parse_file_parallel(lexer, parsing_ctx, consume_ctx, chunking_ctx, result_buffers, CT)
     else
-        result_buf = TaskResultBuffer(0, parsing_ctx.schema, nrows)
+        result_buf = TaskResultBuffer(0, parsing_ctx.schema, cld(nrows, chunking_ctx.nworkers))
         parse_file_serial(lexer, parsing_ctx, consume_ctx, chunking_ctx, result_buf, CT)
     end
 

--- a/src/result_buffer.jl
+++ b/src/result_buffer.jl
@@ -12,8 +12,7 @@ A module implementing a bitflag type used to indicate the status of a row in a `
 - `0x02` -- `TooFewColumns`: The row has fewer fields than expected according to the schema. Implies `HasColumnIndicators`.
 - `0x04` -- `TooManyColumns`: The row has more fields than expected according to the schema.
 - `0x08` -- `ValueParsingError`: Some fields could not be parsed due to an unknown instance of a particular type. Implies `HasColumnIndicators`.
-- `0x10` -- `UnknownTypeError`: Some fields could not be parsed due to an unknown type. Unused.
-- `0x20` -- `SkippedRow`: The row contains no valid values, e.g. it was a comment. Implies `HasColumnIndicators`.
+- `0x10` -- `SkippedRow`: The row contains no valid values, e.g. it was a comment. Implies `HasColumnIndicators`.
 
 Multiple flags can be set at the same time, e.g. `HasColumnIndicators | TooFewColumns` means that at least column in the row does not have a known value and that there were not enough fields in this row.
 If a row has `HasColumnIndicators` flag set, then the `column_indicators` field of the `TaskResultBuffer` will contain a bitset indicating which columns have missing values.
@@ -36,7 +35,7 @@ module RowStatus
     # Used in DebugContext
     const Marks = ('✓', '?', '<', '>', '!', '#')
     const Names = ("Ok", "HasColumnIndicators", "TooFewColumns", "TooManyColumns", "ValueParsingError", "SkippedRow")
-    const Flags = (0x00, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20)
+    const Flags = (0x00, 0x01, 0x02, 0x04, 0x08, 0x10)
 end
 
 """

--- a/src/result_buffer.jl
+++ b/src/result_buffer.jl
@@ -31,12 +31,11 @@ module RowStatus
     const TooFewColumns       = 0x02 # Some fields have missing values due field count mismatch with the schema
     const TooManyColumns      = 0x04 # We have a valid record according to schema, but we didn't parse some fields due to missing schema info
     const ValueParsingError   = 0x08 # We couldn't parse some fields because we don't know how to parse that particular instance of that type
-    const UnknownTypeError    = 0x10 # We couldn't parse some fields because we don't know how to parse any instance of that type
-    const SkippedRow          = 0x20 # The row contains no valid values
+    const SkippedRow          = 0x10 # The row contains no valid values
 
     # Used in DebugContext
-    const Marks = ('✓', '?', '<', '>', '!', 'T', '#')
-    const Names = ("Ok", "HasColumnIndicators", "TooFewColumns", "TooManyColumns", "ValueParsingError", "UnknownTypeError", "SkippedRow")
+    const Marks = ('✓', '?', '<', '>', '!', '#')
+    const Names = ("Ok", "HasColumnIndicators", "TooFewColumns", "TooManyColumns", "ValueParsingError", "SkippedRow")
     const Flags = (0x00, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20)
 end
 


### PR DESCRIPTION
`UnknownTypeError` was a status code we used before we had proper checks on the input schema (we've since moved to [_is_supported_type](https://github.com/RelationalAI/ChunkedCSV.jl/blob/3f5bbe443b0b0a90ab0f2cf6d1dbb59008b24856/src/input_arguments_handling.jl#L25-L35) check instead. I was only used in a dead code branch in `parsecustom!` function and was broken because it was still referencing code we removed when we moved to `BitSetMatrix`.