### PR TITLE
fix: Update FixedPointDecimal compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ChunkedCSV"
 uuid = "c0d0730e-6432-44b2-a51e-6ec55e1c8b99"
 authors = ["Tomáš Drvoštěp <tomas.drvostep@gmail.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 ChunkedBase = "a380dd43-0ebf-4429-88d6-6f06ea920732"

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 [compat]
 ChunkedBase = "0.3"
 Dates = "1"
-FixedPointDecimals = "0.4.3"
+FixedPointDecimals = "0.4.3, 0.5"
 Parsers = "2.7"
 SentinelArrays = "1"
 SnoopPrecompile = "1"


### PR DESCRIPTION
FixedPointDecimal released `v0.5` which includes improved handling of checked arithmetic. This shouldn't affect ChunkedCSV, so we can support this version fine as well