### PR TITLE
Support parsing all DateTimes that could be represented using a 64 bit integer with millisecond resolution

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,8 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
-          - '1.8'
+          - '1.10'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
+BenchmarkTools = "1.6"
 ChunkedBase = "0.3"
 Dates = "1"
 FixedPointDecimals = "0.4.3, 0.5, 0.6"
@@ -24,6 +25,7 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CodecZlibNG = "642d12eb-acb5-4437-bcfc-a25e07ad685c"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -31,4 +33,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [targets]
-test = ["Aqua", "CodecZlibNG", "JET", "Logging", "Test", "UUIDs"]
+test = ["Aqua", "BenchmarkTools", "CodecZlibNG", "JET", "Logging", "Test", "UUIDs"]

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ Parsers = "2.7"
 SentinelArrays = "1"
 SnoopPrecompile = "1"
 TimeZones = "1"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/type_parsers/datetime_parser.jl
+++ b/src/type_parsers/datetime_parser.jl
@@ -20,7 +20,7 @@ Negative years are also supported. The smallest DateTime value that can be repre
 `-292277024-05-15T16:47:04.192` and the largest is `292277025-08-17T07:12:55.807`.
 
 Additionally, since some systems use 32 bit integers to represent years and we don't want to
-fail loudly parsing these even though we can't parse represent them exactly, all valid
+fail loudly parsing these even though we can't represent them exactly, all valid
 timestamps with in the range `[-2147483648-01-01T00:00:00.000, -292277024-05-15T16:47:04.193]`
 will be clamped to the minimal representable DateTime, `-292277024-05-15T16:47:04.192`, and all valid
 timestamps with in the range `[292277025-08-17T07:12:55.808, 2147483647-12-31T23:59:59.999]`
@@ -59,7 +59,7 @@ function _unsafe_datetime(y=0, m=1, d=1, h=0, mi=0, s=0, ms=0)
     rata = ms + 1000 * (s + 60mi + 3600h + 86400 * Dates.totaldays(y, m, d))
     return DateTime(Dates.UTM(rata))
 end
-function _clamped_datetime(y=0, m=1, d=1, h=0, mi=0, s=0, ms=0)
+function _clamped_datetime(y, m, d, h=0, mi=0, s=0, ms=0)
     dt = _unsafe_datetime(y, m, d, h, mi, s, ms)
     y >= 292277025 && dt < ZERO_DATETIME && return MAX_DATETIME
     y <= -292277024 && dt > ZERO_DATETIME && return MIN_DATETIME
@@ -270,7 +270,7 @@ const _Z = SubString("Z", 1:1)
     # the field. So in case we get an invalid TZ here, we just return the _original_ code
     # and `nothing` for the timezone, as if we never attempted to parse it.
     # If this _was_ a true invalid timezone, the other layers in Parsers.jl will mark the value
-    # as invalid because were at the very end of the field and if leave any non-whitespace characters
+    # as invalid because we're at the very end of the field and if we leave any non-whitespace characters
     # between the end of the value and the delimiter, it will be marked as invalid by other layers
     # in Parsers.jl.
     nb = len - pos

--- a/src/type_parsers/datetime_parser.jl
+++ b/src/type_parsers/datetime_parser.jl
@@ -90,8 +90,8 @@ Base.@propagate_inbounds function _default_tryparse_timestamp(buf, pos, len, cod
     delim = options.delim.token
     cq = options.cq.token
     rounding = options.rounding
-    # ensure there is enough room for at least yyyy-m-d
-    if len - pos < 8
+    # ensure there is enough room for at least y-m-d
+    if len - pos + 1 < 5
         (b != delim) && (code |= Parsers.INVALID)
         (pos >= len) && (code |= Parsers.EOF)
         return _unsafe_datetime(0), code, pos
@@ -116,7 +116,7 @@ Base.@propagate_inbounds function _default_tryparse_timestamp(buf, pos, len, cod
         b > 0x09 && (return _unsafe_datetime(0), code | Parsers.INVALID, pos)
         year = Int(b) + 10 * year
         b = buf[pos += 1]
-        (i > 2 && b == UInt8('-')) && break
+        b == UInt8('-') && break
     end
     year *= sign_mul
     if b != UInt8('-') || year > 292277025 || year < -292277024

--- a/test/guess_datetime.jl
+++ b/test/guess_datetime.jl
@@ -21,6 +21,10 @@ macro test_noalloc(e) :(@test(@allocated($(esc(e))) == 0)) end
     end
 
     @testset "Datetimes with only the Date part" begin
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "0-1-1")
+        @test res.val == DateTime(0, 1, 1)
+        @test Parsers.ok(res.code)
+
         res = Parsers.xparse(ChunkedCSV.GuessDateTime, "0-01-01")
         @test res.val == DateTime(0, 1, 1)
         @test Parsers.ok(res.code)

--- a/test/guess_datetime.jl
+++ b/test/guess_datetime.jl
@@ -6,24 +6,45 @@ using Test
 const DT = b"1969-07-20 20:17:00"
 
 macro test_noalloc(e) :(@test(@allocated($(esc(e))) == 0)) end
-function test_utc_equiv(input, expected)
-    res = Parsers.xparse(ChunkedCSV.GuessDateTime, input, 1, length(input), Parsers.OPTIONS, DateTime)
-    @test res.val == expected
-    @test Parsers.ok(res.code)
-    @test_noalloc Parsers.xparse(ChunkedCSV.GuessDateTime, input, 1, length(input), Parsers.OPTIONS, DateTime)
-    return nothing
-end
+
 @testset "GuessDateTime" begin
     @testset "Parsing UTC equivalent timezones does not allocate" begin
         for tz in (b"-00", b"+00", b"-0000", b"+0000", b"-00:00", b"+00:00", b"UTC", b"GMT")
             dt = vcat(DT, tz)
-            @testset "$(String(copy(tz)))" begin
-                test_utc_equiv(dt, DateTime(1969, 7, 20, 20, 17))
+            @testset "$tz" begin
+                res = Parsers.xparse(ChunkedCSV.GuessDateTime, dt, 1, length(dt), Parsers.OPTIONS, DateTime)
+                @test res.val == DateTime(1969, 7, 20, 20, 17)
+                @test Parsers.ok(res.code)
+                @test_noalloc Parsers.xparse(ChunkedCSV.GuessDateTime, dt, 1, length(dt), Parsers.OPTIONS, DateTime)
             end
         end
     end
 
     @testset "Datetimes with only the Date part" begin
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "0-01-01")
+        @test res.val == DateTime(0, 1, 1)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "-0-01-01")
+        @test res.val == DateTime(0, 1, 1)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "1-01-01")
+        @test res.val == DateTime(1, 1, 1)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "-1-01-01")
+        @test res.val == DateTime(-1, 1, 1)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "10-01-01")
+        @test res.val == DateTime(10, 1, 1)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "-10-01-01")
+        @test res.val == DateTime(-10, 1, 1)
+        @test Parsers.ok(res.code)
+
         res = Parsers.xparse(ChunkedCSV.GuessDateTime, "-001-01-01")
         @test res.val == DateTime(-1, 1, 1)
         @test Parsers.ok(res.code)

--- a/test/guess_datetime.jl
+++ b/test/guess_datetime.jl
@@ -2,10 +2,9 @@ using Dates
 using ChunkedCSV
 using Parsers
 using Test
+using BenchmarkTools
 
 const DT = b"1969-07-20 20:17:00"
-
-macro test_noalloc(e) :(@test(@allocated($(esc(e))) == 0)) end
 
 @testset "GuessDateTime" begin
     @testset "Parsing UTC equivalent timezones does not allocate" begin
@@ -15,7 +14,7 @@ macro test_noalloc(e) :(@test(@allocated($(esc(e))) == 0)) end
                 res = Parsers.xparse(ChunkedCSV.GuessDateTime, dt, 1, length(dt), Parsers.OPTIONS, DateTime)
                 @test res.val == DateTime(1969, 7, 20, 20, 17)
                 @test Parsers.ok(res.code)
-                @test_noalloc Parsers.xparse(ChunkedCSV.GuessDateTime, dt, 1, length(dt), Parsers.OPTIONS, DateTime)
+                @ballocated Parsers.xparse(ChunkedCSV.GuessDateTime, $dt, 1, length($dt), Parsers.OPTIONS, DateTime) == 0
             end
         end
     end

--- a/test/guess_datetime.jl
+++ b/test/guess_datetime.jl
@@ -75,48 +75,138 @@ macro test_noalloc(e) :(@test(@allocated($(esc(e))) == 0)) end
     end
 
     @testset "typemin and typemax" begin
-        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(reinterpret(DateTime, typemin(Int))))
-        @test res.val == reinterpret(DateTime, typemin(Int))
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(ChunkedCSV.MIN_DATETIME))
+        @test res.val == ChunkedCSV.MIN_DATETIME
         @test Parsers.ok(res.code)
 
-        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(reinterpret(DateTime, typemax(Int))))
-        @test res.val == reinterpret(DateTime, typemax(Int))
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(ChunkedCSV.MAX_DATETIME))
+        @test res.val == ChunkedCSV.MAX_DATETIME
         @test Parsers.ok(res.code)
 
-        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(reinterpret(DateTime, typemin(Int)), "Z"))
-        @test res.val == reinterpret(DateTime, typemin(Int))
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(ChunkedCSV.MIN_DATETIME, "Z"))
+        @test res.val == ChunkedCSV.MIN_DATETIME
         @test Parsers.ok(res.code)
 
-        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(reinterpret(DateTime, typemax(Int)), "Z"))
-        @test res.val == reinterpret(DateTime, typemax(Int))
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(ChunkedCSV.MAX_DATETIME, "Z"))
+        @test res.val == ChunkedCSV.MAX_DATETIME
         @test Parsers.ok(res.code)
     end
 
-    @testset "overflow due to timezone offset application" begin
-        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(reinterpret(DateTime, typemin(Int)), "+0100"))
-        @test Parsers.invalid(res.code)
 
-        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(reinterpret(DateTime, typemax(Int)), "+0100"))
-        @test res.val == reinterpret(DateTime, typemax(Int)) - Hour(1)
+    @testset "clamping" begin
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(typemax(Int32), "-12-31"))
+        @test res.val == ChunkedCSV.MAX_DATETIME
         @test Parsers.ok(res.code)
 
-        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(reinterpret(DateTime, typemin(Int)), "-0100"))
-        @test res.val == reinterpret(DateTime, typemin(Int)) + Hour(1)
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(typemin(Int32), "-01-01"))
+        @test res.val == ChunkedCSV.MIN_DATETIME
+        @test Parsers.ok(res.code)
 
-        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(reinterpret(DateTime, typemax(Int)), "-0100"))
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(typemax(Int32), "-12-31 23:59:59"))
+        @test res.val == ChunkedCSV.MAX_DATETIME
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(typemin(Int32), "-01-01 00:00:00"))
+        @test res.val == ChunkedCSV.MIN_DATETIME
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(typemax(Int32), "-12-31 23:59:59.999"))
+        @test res.val == ChunkedCSV.MAX_DATETIME
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(typemin(Int32), "-01-01 00:00:00.000"))
+        @test res.val == ChunkedCSV.MIN_DATETIME
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(typemax(Int32), "-12-31 23:59:59.999-0100"))
+        @test res.val == ChunkedCSV.MAX_DATETIME
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(typemin(Int32), "-01-01 00:00:00.000+0100"))
+        @test res.val == ChunkedCSV.MIN_DATETIME
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2147483647-12-31T23:59:59.999")
+        @test res.val == ChunkedCSV.MAX_DATETIME
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "292277025-08-17T07:12:55.808")
+        @test res.val == ChunkedCSV.MAX_DATETIME
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "-2147483648-01-01T00:00:00.000")
+        @test res.val == ChunkedCSV.MIN_DATETIME
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "-292277024-05-15T16:47:04.191")
+        @test res.val == ChunkedCSV.MIN_DATETIME
+        @test Parsers.ok(res.code)
+    end
+
+    @testset "overflow" begin
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(Int(typemax(Int32))+1, "-12-31"))
         @test Parsers.invalid(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(Int(typemin(Int32))-1, "-01-01"))
+        @test Parsers.invalid(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(Int(typemax(Int32))+1, "-12-31 23:59:59"))
+        @test Parsers.invalid(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(Int(typemin(Int32))-1, "-01-01 00:00:00"))
+        @test Parsers.invalid(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(Int(typemax(Int32))+1, "-12-31 23:59:59.999"))
+        @test Parsers.invalid(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(Int(typemin(Int32))-1, "-01-01 00:00:00.000"))
+        @test Parsers.invalid(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2147483648-01-01T00:00:00.000")
+        @test Parsers.invalid(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "-2147483649-12-31T23:59:59.999")
+        @test Parsers.invalid(res.code)
+
+    end
+
+    @testset "clamping due to timezone offset application" begin
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(ChunkedCSV.MIN_DATETIME, "+0100"))
+        @test res.val == ChunkedCSV.MIN_DATETIME # clamped
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(ChunkedCSV.MIN_DATETIME + Hour(1), "+0100"))
+        @test res.val == ChunkedCSV.MIN_DATETIME # exact
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(ChunkedCSV.MIN_DATETIME, "-0100"))
+        @test res.val == ChunkedCSV.MIN_DATETIME + Hour(1)
+        @test Parsers.ok(res.code)
+
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(ChunkedCSV.MAX_DATETIME, "+0100"))
+        @test res.val == ChunkedCSV.MAX_DATETIME - Hour(1)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(ChunkedCSV.MAX_DATETIME, "-0100"))
+        @test res.val == ChunkedCSV.MAX_DATETIME # clamped
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(ChunkedCSV.MAX_DATETIME - Hour(1), "-0100"))
+        @test res.val == ChunkedCSV.MAX_DATETIME # exact
+        @test Parsers.ok(res.code)
 
         # crossing zero due to timezone offset
-        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(reinterpret(DateTime, 0), "-0100"))
-        @test res.val == reinterpret(DateTime, 0) + Hour(1)
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(ChunkedCSV.ZERO_DATETIME, "-0100"))
+        @test res.val == ChunkedCSV.ZERO_DATETIME + Hour(1)
         @test Parsers.ok(res.code)
 
-        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(reinterpret(DateTime, 0), "+0100"))
-        @test res.val == reinterpret(DateTime, 0) - Hour(1)
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(ChunkedCSV.ZERO_DATETIME, "+0100"))
+        @test res.val == ChunkedCSV.ZERO_DATETIME - Hour(1)
         @test Parsers.ok(res.code)
     end
 
-    @testset "" begin
+    @testset "basic" begin
         res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56")
         @test res.val == DateTime(2014, 1, 1, 12, 34, 56)
         @test Parsers.ok(res.code)
@@ -182,10 +272,39 @@ macro test_noalloc(e) :(@test(@allocated($(esc(e))) == 0)) end
         res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.78901Z", rounding=RoundNearest)
         @test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
 
-        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "$(reinterpret(DateTime, typemax(Int)))01Z", rounding=RoundNearest)
-        @test res.val == reinterpret(DateTime, typemax(Int))
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "$(ChunkedCSV.MAX_DATETIME)01Z", rounding=RoundNearest)
+        @test res.val == ChunkedCSV.MAX_DATETIME
 
-        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "$(reinterpret(DateTime, typemin(Int)))01Z", rounding=RoundNearest)
-        @test res.val == reinterpret(DateTime, typemin(Int))
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "$(ChunkedCSV.MIN_DATETIME)01Z", rounding=RoundNearest)
+        @test res.val == ChunkedCSV.MIN_DATETIME
+    end
+
+    @testset "invalid" begin
+        @test Parsers.invalid(Parsers.xparse(ChunkedCSV.GuessDateTime,    "-1-1").code)
+        @test Parsers.invalid(Parsers.xparse(ChunkedCSV.GuessDateTime,    "0--1").code)
+        @test Parsers.invalid(Parsers.xparse(ChunkedCSV.GuessDateTime,    "0-1-").code)
+
+        @test Parsers.ok(     Parsers.xparse(ChunkedCSV.GuessDateTime, "2000-12-31").code)
+        @test Parsers.invalid(Parsers.xparse(ChunkedCSV.GuessDateTime,    "--12-31").code)
+        @test Parsers.invalid(Parsers.xparse(ChunkedCSV.GuessDateTime, "2000-13-31").code)
+        @test Parsers.invalid(Parsers.xparse(ChunkedCSV.GuessDateTime, "2000-12-32").code)
+
+        @test Parsers.ok(     Parsers.xparse(ChunkedCSV.GuessDateTime, "2000-12-31 23:59:59.999").code)
+        @test Parsers.invalid(Parsers.xparse(ChunkedCSV.GuessDateTime,    "--12-31 23:59:59.999").code)
+        @test Parsers.invalid(Parsers.xparse(ChunkedCSV.GuessDateTime, "2000-13-31 23:59:59.999").code)
+        @test Parsers.invalid(Parsers.xparse(ChunkedCSV.GuessDateTime, "2000-12-32 23:59:59.999").code)
+        @test Parsers.invalid(Parsers.xparse(ChunkedCSV.GuessDateTime, "2000-12-31 24:59:59.999").code)
+        @test Parsers.invalid(Parsers.xparse(ChunkedCSV.GuessDateTime, "2000-12-31 23:60:59.999").code)
+        @test Parsers.invalid(Parsers.xparse(ChunkedCSV.GuessDateTime, "2000-13-31 23:59:60.999").code)
+        @test Parsers.invalid(Parsers.xparse(ChunkedCSV.GuessDateTime, "2000-13-31 23:59:60.1000").code)
+
+        @test Parsers.invalid(Parsers.xparse(ChunkedCSV.GuessDateTime, "2000 12-31 23:59:59.999").code)
+        @test Parsers.invalid(Parsers.xparse(ChunkedCSV.GuessDateTime, "2000-12 31 23:59:59.999").code)
+        @test Parsers.invalid(Parsers.xparse(ChunkedCSV.GuessDateTime, "2000-12-31x23-59:59.999").code)
+        @test Parsers.invalid(Parsers.xparse(ChunkedCSV.GuessDateTime, "2000-12-31 23 59:59.999").code)
+        @test Parsers.invalid(Parsers.xparse(ChunkedCSV.GuessDateTime, "2000-12-31 23:59 59.999").code)
+        @test Parsers.invalid(Parsers.xparse(ChunkedCSV.GuessDateTime, "2000-12-31 23:59:59 999").code)
+
+        @test Parsers.ok(     Parsers.xparse(ChunkedCSV.GuessDateTime, "2000-12-31 23:59:59.999N").code)
     end
 end

--- a/test/guess_datetime.jl
+++ b/test/guess_datetime.jl
@@ -7,73 +7,157 @@ const DT = b"1969-07-20 20:17:00"
 
 macro test_noalloc(e) :(@test(@allocated($(esc(e))) == 0)) end
 
-@testset "Parsing UTC equivalent timezones does not allocate" begin
-    for tz in (b"-00", b"+00", b"-0000", b"+0000", b"-00:00", b"+00:00", b"UTC", b"GMT")
-        dt = vcat(DT, tz)
-        @testset "$tz" begin
-            res = Parsers.xparse(ChunkedCSV.GuessDateTime, dt, 1, length(dt), Parsers.OPTIONS, DateTime)
-            @test res.val == DateTime(1969, 7, 20, 20, 17)
-            @test Parsers.ok(res.code)
-            @test_noalloc Parsers.xparse(ChunkedCSV.GuessDateTime, dt, 1, length(dt), Parsers.OPTIONS, DateTime)
+@testset "GuessDateTime" begin
+    @testset "Parsing UTC equivalent timezones does not allocate" begin
+        for tz in (b"-00", b"+00", b"-0000", b"+0000", b"-00:00", b"+00:00", b"UTC", b"GMT")
+            dt = vcat(DT, tz)
+            @testset "$(String(copy(tz)))" begin
+                res = Parsers.xparse(ChunkedCSV.GuessDateTime, dt, 1, length(dt), Parsers.OPTIONS, DateTime)
+                @test res.val == DateTime(1969, 7, 20, 20, 17)
+                @test Parsers.ok(res.code)
+                @test_noalloc Parsers.xparse(ChunkedCSV.GuessDateTime, dt, 1, length(dt), Parsers.OPTIONS, DateTime)
+            end
         end
     end
+
+    @testset "Datetimes with only the Date part" begin
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "-001-01-01")
+        @test res.val == DateTime(-1, 1, 1)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "001-01-01")
+        @test res.val == DateTime(1, 1, 1)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "-201-01-01")
+        @test res.val == DateTime(-201, 1, 1)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "201-01-01")
+        @test res.val == DateTime(201, 1, 1)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "-2014-01-01")
+        @test res.val == DateTime(-2014, 1, 1)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01")
+        @test res.val == DateTime(2014, 1, 1)
+        @test Parsers.ok(res.code)
+    end
+
+    @testset "typemin and typemax" begin
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(reinterpret(DateTime, typemin(Int))))
+        @test res.val == reinterpret(DateTime, typemin(Int))
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(reinterpret(DateTime, typemax(Int))))
+        @test res.val == reinterpret(DateTime, typemax(Int))
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(reinterpret(DateTime, typemin(Int)), "Z"))
+        @test res.val == reinterpret(DateTime, typemin(Int))
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(reinterpret(DateTime, typemax(Int)), "Z"))
+        @test res.val == reinterpret(DateTime, typemax(Int))
+        @test Parsers.ok(res.code)
+    end
+
+    @testset "overflow due to timezone offset application" begin
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(reinterpret(DateTime, typemin(Int)), "+0100"))
+        @test Parsers.invalid(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(reinterpret(DateTime, typemax(Int)), "+0100"))
+        @test res.val == reinterpret(DateTime, typemax(Int)) - Hour(1)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(reinterpret(DateTime, typemin(Int)), "-0100"))
+        @test res.val == reinterpret(DateTime, typemin(Int)) + Hour(1)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(reinterpret(DateTime, typemax(Int)), "-0100"))
+        @test Parsers.invalid(res.code)
+
+        # crossing zero due to timezone offset
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(reinterpret(DateTime, 0), "-0100"))
+        @test res.val == reinterpret(DateTime, 0) + Hour(1)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, string(reinterpret(DateTime, 0), "+0100"))
+        @test res.val == reinterpret(DateTime, 0) - Hour(1)
+        @test Parsers.ok(res.code)
+    end
+
+    @testset "" begin
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56")
+        @test res.val == DateTime(2014, 1, 1, 12, 34, 56)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56")
+        @test res.val == DateTime(2014, 1, 1, 12, 34, 56)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56.7")
+        @test res.val == DateTime(2014, 1, 1, 12, 34, 56, 700)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.7")
+        @test res.val == DateTime(2014, 1, 1, 12, 34, 56, 700)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56.78")
+        @test res.val == DateTime(2014, 1, 1, 12, 34, 56, 780)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.78")
+        @test res.val == DateTime(2014, 1, 1, 12, 34, 56, 780)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56.789")
+        @test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.789")
+        @test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.789Z")
+        @test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.789 Z")
+        @test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56.7890")
+        @test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.7890")
+        @test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
+        @test Parsers.ok(res.code)
+    end
+
+    @testset "rounding" begin
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56.78901", rounding=RoundNearest)
+        @test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.78901", rounding=RoundNearest)
+        @test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56.78901Z", rounding=RoundNearest)
+        @test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
+        @test Parsers.ok(res.code)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.78901Z", rounding=RoundNearest)
+        @test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "$(reinterpret(DateTime, typemax(Int)))01Z", rounding=RoundNearest)
+        @test res.val == reinterpret(DateTime, typemax(Int))
+
+        res = Parsers.xparse(ChunkedCSV.GuessDateTime, "$(reinterpret(DateTime, typemin(Int)))01Z", rounding=RoundNearest)
+        @test res.val == reinterpret(DateTime, typemin(Int))
+    end
 end
-
-res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01")
-@test res.val == DateTime(2014, 1, 1)
-@test Parsers.ok(res.code)
-
-res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56")
-@test res.val == DateTime(2014, 1, 1, 12, 34, 56)
-@test Parsers.ok(res.code)
-
-res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56")
-@test res.val == DateTime(2014, 1, 1, 12, 34, 56)
-@test Parsers.ok(res.code)
-
-res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56.7")
-@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 700)
-@test Parsers.ok(res.code)
-
-res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.7")
-@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 700)
-@test Parsers.ok(res.code)
-
-res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56.78")
-@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 780)
-@test Parsers.ok(res.code)
-
-res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.78")
-@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 780)
-@test Parsers.ok(res.code)
-
-res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56.789")
-@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
-@test Parsers.ok(res.code)
-
-res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.789")
-@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
-@test Parsers.ok(res.code)
-
-res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56.7890")
-@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
-@test Parsers.ok(res.code)
-
-res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.7890")
-@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
-@test Parsers.ok(res.code)
-
-res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56.78901", rounding=RoundNearest)
-@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
-@test Parsers.ok(res.code)
-
-res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.78901", rounding=RoundNearest)
-@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
-@test Parsers.ok(res.code)
-
-res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56.78901Z", rounding=RoundNearest)
-@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
-@test Parsers.ok(res.code)
-
-res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.78901Z", rounding=RoundNearest)
-@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)

--- a/test/guess_datetime.jl
+++ b/test/guess_datetime.jl
@@ -6,16 +6,19 @@ using Test
 const DT = b"1969-07-20 20:17:00"
 
 macro test_noalloc(e) :(@test(@allocated($(esc(e))) == 0)) end
-
+function test_utc_equiv(input, expected)
+    res = Parsers.xparse(ChunkedCSV.GuessDateTime, input, 1, length(input), Parsers.OPTIONS, DateTime)
+    @test res.val == expected
+    @test Parsers.ok(res.code)
+    @test_noalloc Parsers.xparse(ChunkedCSV.GuessDateTime, input, 1, length(input), Parsers.OPTIONS, DateTime)
+    return nothing
+end
 @testset "GuessDateTime" begin
     @testset "Parsing UTC equivalent timezones does not allocate" begin
         for tz in (b"-00", b"+00", b"-0000", b"+0000", b"-00:00", b"+00:00", b"UTC", b"GMT")
             dt = vcat(DT, tz)
             @testset "$(String(copy(tz)))" begin
-                res = Parsers.xparse(ChunkedCSV.GuessDateTime, dt, 1, length(dt), Parsers.OPTIONS, DateTime)
-                @test res.val == DateTime(1969, 7, 20, 20, 17)
-                @test Parsers.ok(res.code)
-                @test_noalloc Parsers.xparse(ChunkedCSV.GuessDateTime, dt, 1, length(dt), Parsers.OPTIONS, DateTime)
+                test_utc_equiv(dt, DateTime(1969, 7, 20, 20, 17))
             end
         end
     end


### PR DESCRIPTION
* Support parsing all DateTimes that could be represented using a 64 bit integer with millisecond resolution, i.e. all values between `-292277024-05-15T16:47:04.192` to `292277025-08-17T07:12:55.807`
     * Additionally, all valid timestamps with in the range `[-2147483648-01-01T00:00:00.000, -292277024-05-15T16:47:04.193]` will be clamped to the minimal representable DateTime, `-292277024-05-15T16:47:04.192`, and all valid timestamps with in the range `[292277025-08-17T07:12:55.808, 2147483647-12-31T23:59:59.999]`
will be clamped to the maximal representable DateTime, `292277025-08-17T07:12:55.807`. 
* Bump the cache github action since v2 is not unsupported anymore
* Bump Julia compat to 1.10 since it's the new LTS and we got reinterpret-related errors in earlier versions.
* I have refactored the code to avoid unnecessary validation, which helped with the failing allocation tests on 1.11 at least and I've added a bunch of tests.