### PR TITLE
Small optimizations for parsing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ChunkedCSV"
 uuid = "c0d0730e-6432-44b2-a51e-6ec55e1c8b99"
 authors = ["Tomáš Drvoštěp <tomas.drvostep@gmail.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 ChunkedBase = "a380dd43-0ebf-4429-88d6-6f06ea920732"

--- a/src/result_buffer.jl
+++ b/src/result_buffer.jl
@@ -220,6 +220,7 @@ function _push_buffers!(::Type{T}, out, i, n) where {T}
 end
 
 Base.length(buf::TaskResultBuffer) = length(buf.row_statuses)
+capacity(buf::TaskResultBuffer) = length(buf.row_statuses.elements)
 
 function Base.empty!(buf::TaskResultBuffer)
     foreach(empty!, buf.cols)


### PR DESCRIPTION
* Don't return a parsed value from `parsecustom!` since that is type unstable
* Don't attempt to grow the result buffer if we have enough capacity
* v0.2.1